### PR TITLE
Configure systemd journal to forward to syslog

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,30 +1,4 @@
 ---
-# If a systemd host lacks the file /sbin/init, then testinfra
-# currently misidentifies it as using SysV.  The relevant code can be
-# viewed here:
-# https://github.com/philpep/testinfra/blob/master/testinfra/modules/service.py#L51-L63.
-#
-# The Ubuntu and Debian Docker images that we are using suffer from
-# this issue; therefore, we need to install the init package as a
-# workaround.  Any real (non-Docker) host will have this package
-# installed anyway.
-#
-# This is a known testinfra issue.  See
-# https://github.com/philpep/testinfra/issues/416 for more details.
-- name: Group hosts by OS family
-  hosts: all
-  tasks:
-    - name: Group hosts by OS family
-      group_by:
-        key: os_{{ ansible_facts['os_family'] }}
-- name: Install init (Debian)
-  hosts: os_Debian
-  tasks:
-    - name: Install init (Debian)
-      package:
-        name:
-          - init
-
 # The Ubuntu 16.04 Docker image we are using
 # (geerlingguy/docker-ubuntu1604-ansible:latest) needs a cache update
 # before it can install anything.
@@ -53,3 +27,29 @@
         name: "*"
         state: latest
         update_cache: yes
+
+# If a systemd host lacks the file /sbin/init, then testinfra
+# currently misidentifies it as using SysV.  The relevant code can be
+# viewed here:
+# https://github.com/philpep/testinfra/blob/master/testinfra/modules/service.py#L51-L63.
+#
+# The Ubuntu and Debian Docker images that we are using suffer from
+# this issue; therefore, we need to install the init package as a
+# workaround.  Any real (non-Docker) host will have this package
+# installed anyway.
+#
+# This is a known testinfra issue.  See
+# https://github.com/philpep/testinfra/issues/416 for more details.
+- name: Group hosts by OS family
+  hosts: all
+  tasks:
+    - name: Group hosts by OS family
+      group_by:
+        key: os_{{ ansible_facts['os_family'] }}
+- name: Install init (Debian)
+  hosts: os_Debian
+  tasks:
+    - name: Install init (Debian)
+      package:
+        name:
+          - init

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["amazon-cloudwatch-agent"])
+@pytest.mark.parametrize("pkg", ["amazon-cloudwatch-agent", "rsyslog"])
 def test_packages(host, pkg):
     """Test that the expected packages were installed."""
     assert host.package(pkg).is_installed
@@ -28,7 +28,7 @@ def test_files(host, f):
     assert host.file(f).mode == 0o600
 
 
-@pytest.mark.parametrize("service", ["amazon-cloudwatch-agent"])
+@pytest.mark.parametrize("service", ["amazon-cloudwatch-agent", "rsyslog"])
 def test_services(host, service):
     """Test that the expected services were enabled."""
     assert host.service(service).is_enabled

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -32,3 +32,12 @@ def test_files(host, f):
 def test_services(host, service):
     """Test that the expected services were enabled."""
     assert host.service(service).is_enabled
+
+
+def test_systemd_journald_config(host):
+    """Test that the journald config was altered as expected."""
+    f = host.file("/etc/systemd/journald.conf")
+    assert f.exists
+    assert f.is_file
+    assert f.contains(r"^ForwardToSyslog=yes")
+    assert not f.contains(r"^ForwardToSyslog=no")

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -41,3 +41,4 @@ def test_systemd_journald_config(host):
     assert f.is_file
     assert f.contains(r"^ForwardToSyslog=yes")
     assert not f.contains(r"^ForwardToSyslog=no")
+    assert f.contains(r"^MaxLevelSyslog=debug")

--- a/molecule/ubuntu-only/prepare.yml
+++ b/molecule/ubuntu-only/prepare.yml
@@ -1,4 +1,20 @@
 ---
+# The Ubuntu 16.04 Docker image we are using
+# (geerlingguy/docker-ubuntu1604-ansible:latest) needs a cache update
+# before it can install anything.
+- name: Group hosts by OS distribution and major version
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution and major version
+      group_by:
+        key: os_{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}
+- name: Update apt cache (Ubuntu 16)
+  hosts: os_Ubuntu_16
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
 # If a systemd host lacks the file /sbin/init, then testinfra
 # currently misidentifies it as using SysV.  The relevant code can be
 # viewed here:
@@ -24,19 +40,3 @@
       package:
         name:
           - init
-
-# The Ubuntu 16.04 Docker image we are using
-# (geerlingguy/docker-ubuntu1604-ansible:latest) needs a cache update
-# before it can install anything.
-- name: Group hosts by OS distribution and major version
-  hosts: all
-  tasks:
-    - name: Group hosts by OS distribution and major version
-      group_by:
-        key: os_{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}
-- name: Update apt cache (Ubuntu 16)
-  hosts: os_Ubuntu_16
-  tasks:
-    - name: Update apt cache
-      apt:
-        update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,17 +62,20 @@
     - cloudwatch-agent
     - rsyslog
 
-# Configure systemd-journald to forward journal logs to rsyslog, so
-# that the Amazon CloudWatch Agent can in turn forward them to
+# Configure systemd-journald to forward all journal logs to rsyslog,
+# so that the Amazon CloudWatch Agent can in turn forward them to
 # CloudWatch.
 - name: Forward journald log entries to rsyslog
   lineinfile:
     path: /etc/systemd/journald.conf
-    regexp: '^#?ForwardToSyslog'
-    line: ForwardToSyslog=yes
+    regexp: '{{ item.regex }}'
+    line: '{{ item.line }}'
     # This forces lineinfile not to append the line if the regex fails
     # to match
     backrefs: yes
+  loop:
+    - {regex: '^#?ForwardToSyslog', line: "ForwardToSyslog=yes"}
+    - {regex: '^#?MaxLevelSyslog', line: "MaxLevelSyslog=debug"}
   tags:
     - cloudwatch-agent
     - journald

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,10 +48,24 @@
   tags:
     - cloudwatch-agent
 
-# Configure systemd-journald to forward journal logs to syslog, so
+- name: Install and enable rsyslog
+  block:
+    - name: Install rsyslog
+      package:
+        name:
+          - rsyslog
+    - name: Enable rsyslog
+      service:
+        name: rsyslog
+        enabled: yes
+  tags:
+    - cloudwatch-agent
+    - rsyslog
+
+# Configure systemd-journald to forward journal logs to rsyslog, so
 # that the Amazon CloudWatch Agent can in turn forward them to
 # CloudWatch.
-- name: Forward journald log entries to syslog
+- name: Forward journald log entries to rsyslog
   lineinfile:
     path: /etc/systemd/journald.conf
     regexp: '^#?ForwardToSyslog'
@@ -59,3 +73,6 @@
     # This forces lineinfile not to append the line if the regex fails
     # to match
     backrefs: yes
+  tags:
+    - cloudwatch-agent
+    - journald

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
   when: ansible_facts['os_family'] == 'RedHat'
   tags:
     - cloudwatch-agent
+
 # Note that we are using a single config file for all instances,
 # regardless of Linux distribution.  This means that the config file
 # may well (and most likely does) reference log files that do not
@@ -35,6 +36,7 @@
     mode: 0600
   tags:
     - cloudwatch-agent
+
 # The AWS CloudWatch Agent systemd unit kicks off a process that
 # starts the CloudWatch Agent and then dies.  Therefore we can't start
 # it here because it will be started again during the idempotence test
@@ -45,3 +47,15 @@
     enabled: yes
   tags:
     - cloudwatch-agent
+
+# Configure systemd-journald to forward journal logs to syslog, so
+# that the Amazon CloudWatch Agent can in turn forward them to
+# CloudWatch.
+- name: Forward journald log entries to syslog
+  lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#?ForwardToSyslog'
+    line: ForwardToSyslog=yes
+    # This forces lineinfile not to append the line if the regex fails
+    # to match
+    backrefs: yes


### PR DESCRIPTION
This way any logs that are sent to journald will be forwarded by Amazon CloudWatch Agent to CloudWatch.