### PR TITLE
Add Kali support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        # Kali linux isn't an option here, but it is based on Debian
+        # testing
+        - bullseye
     - name: Fedora
       versions:
         - 29
@@ -21,6 +24,10 @@ galaxy_info:
         # can't use Fedora 30.
         # - 30
         - 31
+    - name: Ubuntu
+      versions:
+        - bionic
+        - xenial
   galaxy_tags:
     - agent
     - aws

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -51,6 +51,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
+  - name: kali_systemd
+    image: cisagov/docker-kali-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: ubuntu_bionic_systemd
     image: geerlingguy/docker-ubuntu1604-ansible:latest
     privileged: yes
@@ -67,6 +74,13 @@ platforms:
     pre_build_image: yes
 provisioner:
   name: ansible
+  config_options:
+    # The OS family and distribution for Kali is "Kali GNU/Linux",
+    # which is not an allowable group name in Ansible due to the space
+    # and the slash.  This option converts those characters to
+    # underscores when creating the group name.
+    defaults:
+      force_valid_group_names: always
   lint:
     name: ansible-lint
 scenario:


### PR DESCRIPTION
## 🗣 Description

This pull request adds support (molecule testing) for Kali Linux.  I didn't do this before because I couldn't find a systemd-enabled Kali Docker image, and I was assuming that Kali would work identically to Debian.  This appears not to be the case, so I created [a systemd-enabled Kali Docker image](https://github.com/cisagov/docker-kali-ansible) for use here.

## 💭 Motivation and Context

We need AWS CloudWatch Agent support for the Kali AMI we are building for the COOL.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
