### PR TITLE
Fix a typo in the CloudWatch Agent config file

### DIFF
--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -106,7 +106,7 @@
           },
           {
             "file_path": "/var/log/messages",
-            "log_group_name": "/instance-logs/kessages",
+            "log_group_name": "/instance-logs/messages",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%b %d %H:%M:%S"
           }


### PR DESCRIPTION
## 🗣 Description

The `/var/log/messages` logs were being sent the `/instance-logs/kessages` log group.  This PR corrects that and sends them to the `/instance-logs/messages` log group instead.

## 💭 Motivation and Context

Eschewance of confusion and obfuscation.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
