### PR TITLE
Pull in upstream updates and work around unsigned RPM failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @jsf9k

--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+
+lineage:
+  skeleton:
+    remote-url: https://github.com/cisagov/skeleton-generic.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
 ---
 name: build
 
-on: [
-  push,
-  pull_request
-]
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [apb]
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,22 +23,18 @@ jobs:
         run: |
           echo "::set-env name=PY_VERSION::"\
           "$(python -c "import platform;print(platform.python_version())")"
-      - name: Cache pip test requirements
-        uses: actions/cache@v1
+      - name: Cache linting environments
+        uses: actions/cache@v2
         with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
-            ${{ hashFiles('**/requirements-test.txt') }}"
-          restore-keys: |
-            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
-            ${{ runner.os }}-pip-test-
-            ${{ runner.os }}-pip-
-      - name: Cache pre-commit hooks
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
+          path: |
+            ${{ env.PIP_CACHE_DIR }}
+            ${{ env.PRE_COMMIT_CACHE_DIR }}
+          key: "${{ runner.os }}-lint-py${{ env.PY_VERSION }}-\
+            ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
+          restore-keys: |
+            ${{ runner.os }}-lint-py${{ env.PY_VERSION }}-
+            ${{ runner.os }}-lint-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,12 @@ jobs:
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "${{ runner.os }}-lint-py${{ env.PY_VERSION }}-\
+          key: "lint-${{ runner.os }}-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            ${{ runner.os }}-lint-py${{ env.PY_VERSION }}-
-            ${{ runner.os }}-lint-
+            lint-${{ runner.os }}-py${{ env.PY_VERSION }}-
+            lint-${{ runner.os }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Store installed Python version

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,6 @@ import_heading_firstparty=cisagov Libraries
 known_third_party=
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=
+
+# Run isort under the black profile to align with our other Python linting
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -27,7 +27,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.0
+    rev: v0.23.2
     hooks:
       - id: markdownlint
         args:
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.4.1
+    rev: v2.7.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,20 +61,20 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.1
+    rev: v2.2.0
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.0.7
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.3.0a0
+    rev: v4.3.0a3
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.30.0
+    rev: v1.31.0
     hooks:
       - id: terraform_fmt
       # There are ongoing issues with how this command works. This issue
@@ -94,7 +94,7 @@ repos:
       # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.1
+    rev: v2.0.0
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
@@ -102,6 +102,6 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.782
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
       # https://github.com/hashicorp/terraform/pull/24896
       # is a proprosed fix to deal with `terraform validate` with proxy
       # providers (among other configurations).
+      # We have decided to disable the terraform_validate hook until the issues
+      # above have been resolved, which we hope will be with the release of
+      # Terraform 0.13.
       # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.0a2
+    rev: 3.8.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,10 +64,10 @@ repos:
     rev: v2.1.1
     hooks:
       - id: seed-isort-config
-  - repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/timothycrosley/isort
     # pick the isort version you'd like to use from
     # https://github.com/pre-commit/mirrors-isort/releases
-    rev: v4.3.21
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.21.0
+    rev: v1.23.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -41,13 +41,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.4.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,12 +71,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -85,7 +85,7 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,19 @@ repos:
     rev: v1.30.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # There are ongoing issues with how this command works. This issue
+      # documents the core issue:
+      # https://github.com/hashicorp/terraform/issues/21408
+      # We have seen issues primarily with proxy providers and Terraform code
+      # that uses remote state. The PR
+      # https://github.com/hashicorp/terraform/pull/24887
+      # has been approved and is part of the 0.13 release to resolve the issue
+      # with remote states.
+      # The PR
+      # https://github.com/hashicorp/terraform/pull/24896
+      # is a proprosed fix to deal with `terraform validate` with proxy
+      # providers (among other configurations).
+      # - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,6 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
-    # pick the isort version you'd like to use from
-    # https://github.com/pre-commit/mirrors-isort/releases
     rev: 4.3.21
     hooks:
       - id: isort

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ If you already have `pyenv` and `pyenv-virtualenv` configured you can
 take advantage of the `setup-env` tool in this repo to automate the
 entire environment configuration process.
 
-```bash
+```console
 ./setup-env
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,9 @@ environment.
 
 #### Installing and using `pyenv` and `pyenv-virtualenv` ####
 
-On the Mac, installation is as simple as `brew install pyenv
-pyenv-virtualenv` and adding this to your profile:
+On the Mac, we recommend installing [brew](https://brew.sh/).  Then
+installation is as simple as `brew install pyenv pyenv-virtualenv` and
+adding this to your profile:
 
 ```bash
 eval "$(pyenv init -)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ There are a few ways to do this, but we prefer to use
 create and manage a Python virtual environment specific to this
 project.
 
+If you already have `pyenv` and `pyenv-virtualenv` configured you can
+take advantage of the `setup-env` tool in this repo to automate the
+entire environment configuration process.
+
+```bash
+./setup-env
+```
+
+Otherwise, follow the steps below to manually configure your
+environment.
+
 #### Installing and using `pyenv` and `pyenv-virtualenv` ####
 
 On the Mac, installation is as simple as `brew install pyenv

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,12 +19,9 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 29
-        # Ansible currently insists on installing python2-dnf, which
-        # does not exist in Fedora 30.  Until that is resolved, we
-        # can't use Fedora 30.
-        # - 30
         - 31
+        - 32
+        - 33
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,8 @@ galaxy_info:
   author: First Last
   description: Skeleton Ansible role
   company: CISA Cyber Assessments
+  galaxy_tags:
+    - skeleton
   license: CC0
   min_ansible_version: 2.0
   platforms:
@@ -25,7 +27,6 @@ galaxy_info:
       versions:
         - bionic
         - xenial
-  galaxy_tags:
-    - skeleton
+  role_name: skeleton
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 31
         - 32
         - 33
     - name: Ubuntu

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -51,15 +51,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  # Remove fedora33 for now, since it can't even perform a dnf upgrade
-  # because of GPG signature errors.
-  # - name: fedora33_systemd
-  #   image: cisagov/docker-fedora33-ansible:latest
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   command: /lib/systemd/systemd
-  #   pre_build_image: yes
+  - name: fedora33_systemd
+    image: cisagov/docker-fedora33-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: ubuntu_bionic_systemd
     image: geerlingguy/docker-ubuntu1604-ansible:latest
     privileged: yes

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,15 +20,12 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora29
-    image: fedora:29
-  # Ansible currently insists on installing python2-dnf, which does
-  # not exist in Fedora 30.  Until that is resolved, we can't use
-  # Fedora 30.
-  # - name: fedora30
-  #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: fedora32
+    image: fedora:32
+  - name: fedora33
+    image: fedora:33
   - name: ubuntu16
     image: ubuntu:xenial
   - name: ubuntu18

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,8 +20,6 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora31
-    image: fedora:31
   - name: fedora32
     image: fedora:32
   - name: fedora33

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,6 @@
+---
+- name: Import upgrade playbook
+  import_playbook: upgrade.yml
+
+- name: Import python playbook
+  import_playbook: python.yml

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  name: Install pip3/python3 and remove pip2/python2
+  become: yes
+  become_method: sudo
+  roles:
+    - pip
+    - python
+    - remove_python2

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,4 @@
+---
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
 - src: https://github.com/cisagov/ansible-role-python

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,8 @@
+- src: https://github.com/cisagov/ansible-role-pip
+  name: pip
+- src: https://github.com/cisagov/ansible-role-python
+  name: python
+- src: https://github.com/cisagov/ansible-role-remove-python2
+  name: remove_python2
+- src: https://github.com/cisagov/ansible-role-upgrade
+  name: upgrade

--- a/molecule/default/upgrade.yml
+++ b/molecule/default/upgrade.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  name: Upgrade base image
+  become: yes
+  become_method: sudo
+  roles:
+    - upgrade

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
+--requirement requirements.txt
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel

--- a/setup-env
+++ b/setup-env
@@ -69,8 +69,9 @@ if [ -z "$(command -v pyenv)" ] || [ -z "$(command -v pyenv-virtualenv)" ]; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     cat << 'END_OF_LINE'
 
-  On the Mac, installation is as simple as "brew install pyenv
-  pyenv-virtualenv" and adding this to your profile:
+  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  is as simple as `brew install pyenv pyenv-virtualenv` and adding this to your
+  profile:
 
   eval "$(pyenv init -)"
   eval "$(pyenv virtualenv-init -)"

--- a/setup-env
+++ b/setup-env
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+USAGE=$(cat << 'END_OF_LINE'
+This script is used to configure a developement environment for this repo.
+
+It does the following:
+  - Verifies pyenv and pyenv-virtualenv are installed.
+  - Creates a Python virtual environment.
+  - Configures the activation of the virtual enviroment for the repo directory.
+  - Installs the requirements required for development.
+  - Installs git pre-commit hooks.
+  - Configures git upstream remote "lineage" repositories.
+
+usage: setup-env [--force] [--help] [virt_env_name]
+
+END_OF_LINE
+)
+
+# Flag to force deletion and creation of virtual environment
+FORCE=0
+
+# Positional parameters
+PARAMS=""
+
+# Parse command line arguments
+while (( "$#" )); do
+  case "$1" in
+    -f|--force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      echo "${USAGE}"
+      exit 0
+      ;;
+    -*) # unsupported flags
+       echo "Error: Unsupported flag $1" >&2
+       exit 1
+       ;;
+    *) # preserve positional arguments
+       PARAMS="$PARAMS $1"
+       shift
+       ;;
+      esac
+done
+
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+# Check to see if pyenv is installed
+if [ -z "$(which pyenv)" ] || [ -z "$(which pyenv-virtualenv)" ]; then
+  echo "pyenv and pyenv-virtualenv are required."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    cat << 'END_OF_LINE'
+
+  On the Mac, installation is as simple as "brew install pyenv
+  pyenv-virtualenv" and adding this to your profile:
+
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+
+END_OF_LINE
+
+  fi
+  cat << 'END_OF_LINE'
+  For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you don't want
+  to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
+  the necessary tools. Before running this ensure that you have installed the
+  prerequisites for your platform according to the pyenv wiki page,
+  https://github.com/pyenv/pyenv/wiki/common-build-problems.
+
+  On WSL you should treat your platform as whatever Linux distribution you've
+  chosen to install.
+
+  Once you have installed "pyenv" you will need to add the following lines to
+  your ".bashrc":
+
+  export PATH="$PATH:$HOME/.pyenv/bin"
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+END_OF_LINE
+  exit 1
+fi
+
+set +o nounset
+# Determine the virtual environment name
+if [ "$1" ]; then
+  # Use the user-provided environment name
+  env_name=$1
+else
+  # Set the environment name to the last part of the working directory.
+  env_name=${PWD##*/}
+fi
+set -o nounset
+
+# Remove any lingering local configuration.
+if [ $FORCE -ne 0 ]; then
+  rm -f .python-version
+  pyenv virtualenv-delete --force "${env_name}" || true
+elif [[ -f .python-version ]]; then
+  cat << 'END_OF_LINE'
+  An existing .python-version file was found.  Either remove this file yourself
+  or re-run with --force option to have it deleted along with the associated
+  virtual environment.
+
+  rm .python-version
+
+END_OF_LINE
+  exit 1
+fi
+
+# Create a new virutal environment for this project
+if ! pyenv virtualenv "${env_name}"; then
+  cat << END_OF_LINE
+  An existing virtual environment named $env_name was found.  Either delete this
+  environment yourself or re-run with --force option to have it deleted.
+
+  pyenv virtualenv-delete ${env_name}
+
+END_OF_LINE
+  exit 1
+fi
+
+# Activate the new virtual environment
+pyenv local "${env_name}"
+
+# Upgrade pip and friends
+python -m pip install --upgrade pip setuptools wheel
+
+# Find a requirements file (if possible) and install
+for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do
+  if [[ -f $req_file ]]
+  then
+    pip install -r $req_file
+    break
+  fi
+done
+
+# Install git pre-commit hooks
+pre-commit install
+
+# Setup git remotes from lineage configuration
+# This could fail if the remotes are already setup, but that is ok.
+set +o errexit
+
+eval "$(python3 << 'END_OF_LINE'
+from pathlib import Path
+import yaml
+import sys
+
+LINEAGE_CONFIG = Path(".github/lineage.yml")
+
+if not LINEAGE_CONFIG.exists():
+    print('No lineage configuration found.', file=sys.stderr)
+    sys.exit(0)
+
+with LINEAGE_CONFIG.open("r") as f:
+    lineage = yaml.safe_load(stream=f)
+
+if lineage["version"] == "1":
+    for parent_name, v in lineage["lineage"].items():
+        remote_url = v["remote-url"]
+        print(f"git remote add {parent_name} {remote_url};")
+        print(f"git remote set-url --push {parent_name} no_push;")
+else:
+    print(f'Unsupported lineage version: {lineage["version"]}', file=sys.stderr)
+END_OF_LINE
+)"
+
+# Qapla
+echo "Success!"

--- a/setup-env
+++ b/setup-env
@@ -37,6 +37,10 @@ PARAMS=""
 # Parse command line arguments
 while (( "$#" )); do
   case "$1" in
+    -i|--install-hooks)
+      INSTALL_HOOKS=1
+      shift
+      ;;
     -f|--force)
       FORCE=1
       shift
@@ -148,8 +152,8 @@ for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt
   fi
 done
 
-# Install git pre-commit hooks
-pre-commit install
+# Install git pre-commit hooks now or later.
+pre-commit install ${INSTALL_HOOKS:+"--install-hooks"}
 
 # Setup git remotes from lineage configuration
 # This could fail if the remotes are already setup, but that is ok.

--- a/setup-env
+++ b/setup-env
@@ -125,7 +125,8 @@ END_OF_LINE
   exit 1
 fi
 
-# Activate the new virtual environment
+# Set the local application-specific Python version(s) by writing the
+# version name to a file named `.python-version'.
 pyenv local "${env_name}"
 
 # Upgrade pip and friends

--- a/setup-env
+++ b/setup-env
@@ -134,9 +134,8 @@ python3 -m pip install --upgrade pip setuptools wheel
 
 # Find a requirements file (if possible) and install
 for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do
-  if [[ -f $req_file ]]
-  then
-    pip install -r $req_file
+  if [[ -f $req_file ]]; then
+    pip install --requirement $req_file
     break
   fi
 done

--- a/setup-env
+++ b/setup-env
@@ -37,10 +37,6 @@ PARAMS=""
 # Parse command line arguments
 while (( "$#" )); do
   case "$1" in
-    -i|--install-hooks)
-      INSTALL_HOOKS=1
-      shift
-      ;;
     -f|--force)
       FORCE=1
       shift
@@ -48,6 +44,10 @@ while (( "$#" )); do
     -h|--help)
       echo "${USAGE}"
       exit 0
+      ;;
+    -i|--install-hooks)
+      INSTALL_HOOKS=1
+      shift
       ;;
     -*) # unsupported flags
        echo "Error: Unsupported flag $1" >&2

--- a/setup-env
+++ b/setup-env
@@ -168,7 +168,7 @@ import sys
 LINEAGE_CONFIG = Path(".github/lineage.yml")
 
 if not LINEAGE_CONFIG.exists():
-    print('No lineage configuration found.', file=sys.stderr)
+    print("No lineage configuration found.", file=sys.stderr)
     sys.exit(0)
 
 with LINEAGE_CONFIG.open("r") as f:

--- a/setup-env
+++ b/setup-env
@@ -113,7 +113,7 @@ END_OF_LINE
   exit 1
 fi
 
-# Create a new virutal environment for this project
+# Create a new virtual environment for this project
 if ! pyenv virtualenv "${env_name}"; then
   cat << END_OF_LINE
   An existing virtual environment named $env_name was found.  Either delete this

--- a/setup-env
+++ b/setup-env
@@ -64,7 +64,7 @@ done
 eval set -- "$PARAMS"
 
 # Check to see if pyenv is installed
-if [ -z "$(which pyenv)" ] || [ -z "$(which pyenv-virtualenv)" ]; then
+if [ -z "$(command -v pyenv)" ] || [ -z "$(command -v pyenv-virtualenv)" ]; then
   echo "pyenv and pyenv-virtualenv are required."
   if [[ "$OSTYPE" == "darwin"* ]]; then
     cat << 'END_OF_LINE'

--- a/setup-env
+++ b/setup-env
@@ -130,7 +130,7 @@ fi
 pyenv local "${env_name}"
 
 # Upgrade pip and friends
-python -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip setuptools wheel
 
 # Find a requirements file (if possible) and install
 for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do

--- a/setup-env
+++ b/setup-env
@@ -16,7 +16,7 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env [--force] [virt_env_name]
+  setup-env [options] [virt_env_name]
   setup-env (-h | --help)
 
 Options:

--- a/setup-env
+++ b/setup-env
@@ -5,17 +5,25 @@ set -o errexit
 set -o pipefail
 
 USAGE=$(cat << 'END_OF_LINE'
-This script is used to configure a developement environment for this repo.
+Configure a developement environment for this repository.
 
 It does the following:
   - Verifies pyenv and pyenv-virtualenv are installed.
   - Creates a Python virtual environment.
   - Configures the activation of the virtual enviroment for the repo directory.
-  - Installs the requirements required for development.
+  - Installs the requirements needed for development.
   - Installs git pre-commit hooks.
   - Configures git upstream remote "lineage" repositories.
 
-usage: setup-env [--force] [--help] [virt_env_name]
+Usage:
+  setup-env [--force] [virt_env_name]
+  setup-env (-h | --help)
+
+Options:
+  -f --force          Delete virtual enviroment if it already exists.
+  -h --help           Show this message.
+  -i --install-hooks  Install hook environments for all environments in the
+                      pre-commit config file.
 
 END_OF_LINE
 )

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install AWS CloudWatch Agent RPM via dnf
   dnf:
+    # The amazon-ssm-agent RPM is currently unsigned:
+    # https://github.com/aws/amazon-ssm-agent/issues/235
     disable_gpg_check: yes
     name:
       - "{{ url }}"

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -1,5 +1,6 @@
 ---
 - name: Install AWS CloudWatch Agent RPM via dnf
   dnf:
+    disable_gpg_check: yes
     name:
       - "{{ url }}"


### PR DESCRIPTION
## 🗣 Description

In this pull request I:
* Pull in upstream updates so that this repo benefits from "recent" improvements such as [lineage](https://github.com/cisagov/action-lineage)
* Add a workaround for the fact that `dnf`/`rpm`/`yum` cannot verify the signature of the Cloudwatch Agent RPM
* Remove Fedora 33 from the molecule tests since Fedora 33 is currently borked; it cannot even perform a simple `dnf update` because of GPG signature issues with Fedora RPMs

## 💭 Motivation and Context

This change is required because this Ansible role is required to build our COOL AMIs.

## 🧪 Testing

All pre-commit hooks and molecule tests pass. I am in the process of building a new FreeIPA image using this branch and will update this paragraph after testing.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
