### PR TITLE
Improve CloudWatch Agent configuration file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -7,10 +7,24 @@
       "files": {
         "collect_list": [
           {
+            "file_path": "/var/alternatives.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "alternatives",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "update-alternatives %Y-%m-%d %H:%M:%S"
+          },
+          {
             "file_path": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "amazon-cloudwatch-agent",
             "timestamp_format": "%Y/%m/%d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/amazon/ssm/*.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "amazon-ssm-agent",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/aide/aide.log",
@@ -21,32 +35,26 @@
             "file_path": "/var/log/apt/history.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "apt/history",
-            "multi_line_start_pattern": "Start-Date: {timestamp_format}",
-            "timestamp_format": "%Y-%m-%d  %H:%M:%S"
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "Start-Date: %Y-%m-%d  %H:%M:%S"
           },
           {
             "file_path": "/var/log/auth.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "auth",
-            "timestamp_format": "%b %d %H:%M:%S"
-          },
-          {
-            "file_path": "/var/log/dpkg.log",
-            "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "dpkg",
-            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+            "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/clamav/freshclam.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/freshclam",
-            "timestamp_format": "%a %b %d %H:%M:%S %Y"
+            "timestamp_format": "%a %b %-d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/freshclam.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/freshclam",
-            "timestamp_format": "%a %b %d %H:%M:%S %Y"
+            "timestamp_format": "%a %b %-d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/clamav/lastscan.log",
@@ -68,13 +76,13 @@
             "file_path": "/var/log/daemon.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "daemon",
-            "timestamp_format": "%b %d %H:%M:%S"
+            "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/debug",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "debug",
-            "timestamp_format": "%b %d %H:%M:%S"
+            "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/dirsrv/slapd-*/access",
@@ -114,6 +122,12 @@
             "log_stream_name": "dnf/rpm",
             "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"
+          },
+          {
+            "file_path": "/var/log/dpkg.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dpkg",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/hawkey.log",
@@ -205,7 +219,7 @@
             "file_path": "/var/log/kern.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "kern",
-            "timestamp_format": "%b %d %H:%M:%S"
+            "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/krb5kdc.log",
@@ -250,7 +264,25 @@
             "file_path": "/var/log/syslog",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "syslog",
-            "timestamp_format": "%b %d %H:%M:%S"
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/ufw.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ufw",
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/unattended-upgrades/*.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "unattended-upgrades",
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/user.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "user",
+            "timestamp_format": "%b %-d %H:%M:%S"
           }
         ]
       }

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -8,104 +8,104 @@
         "collect_list": [
           {
             "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "amazon-cloudwatch-agent",
             "timestamp_format": "%Y/%m/%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/aide/aide.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "aide"
           },
           {
             "file_path": "/var/log/apt/history.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "apt/history",
             "multi_line_start_pattern": "Start-Date: {timestamp_format}",
             "timestamp_format": "%Y-%m-%d  %H:%M:%S"
           },
           {
             "file_path": "/var/log/dpkg.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "dpkg",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/clamav/freshclam.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/freshclam",
             "timestamp_format": "%a %b %d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/freshclam.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/freshclam",
             "timestamp_format": "%a %b %d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/clamav/lastscan.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/lastscan"
           },
           {
             "file_path": "/var/log/cloud-init.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "cloud-init",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/cloud-init-output.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "cloud-init-output"
           },
           {
             "file_path": "/var/log/ipaclient-install.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipaclient-install"
           },
           {
             "file_path": "/var/log/ipaclient-uninstall.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipaclient-uninstall"
           },
           {
             "file_path": "/var/log/ipaserver-install.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipaserver-install"
           },
           {
             "file_path": "/var/log/syslog",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "syslog",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/auth.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "auth",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/daemon.log",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "daemon",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/debug",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "debug",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/kern.log",
-            "log_group_name": "/instance-logs/{instance-id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "kern",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/messages",
-            "log_group_name": "/instance-logs/{instance_id}",
+            "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "messages",
             "timestamp_format": "%b %d %H:%M:%S"
           }

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -42,12 +42,14 @@
             "file_path": "/var/log/apache2/error_log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "apache2/error",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "[%a %b %d %H:%M:%S.%f %Y]"
           },
           {
             "file_path": "/var/log/apache2/ssl_request_log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "apache2/ssl_request",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "[%d/%b/%Y:%H:%M:%S.%f %z]"
           },
           {
@@ -61,18 +63,21 @@
             "file_path": "/var/log/auth.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "auth",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/clamav/freshclam.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/freshclam",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%a %b %-d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/freshclam.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "clamav/freshclam",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%a %b %-d %H:%M:%S %Y"
           },
           {
@@ -96,30 +101,35 @@
             "file_path": "/var/log/daemon.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "daemon",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/debug",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "debug",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/dirsrv/slapd-*/access",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "dirsrv/slapd/access",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%d/%b/%Y:%H:%M:%S.%f %z"
           },
           {
             "file_path": "/var/log/dirsrv/slapd-*/audit",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "dirsrv/slapd/audit",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%d/%b/%Y:%H:%M:%S.%f %z"
           },
           {
             "file_path": "/var/log/dirsrv/slapd-*/errors",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "dirsrv/slapd/errors",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%d/%b/%Y:%H:%M:%S.%f %z"
           },
           {
@@ -147,12 +157,14 @@
             "file_path": "/var/log/dpkg.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "dpkg",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/hawkey.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "hawkey",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"
           },
           {
@@ -164,12 +176,14 @@
             "file_path": "/var/log/httpd/error_log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "httpd/error",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "[%a %b %d %H:%M:%S.%f %Y]"
           },
           {
             "file_path": "/var/log/httpd/ssl_request_log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "httpd/ssl_request",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "[%d/%b/%Y:%H:%M:%S.%f %z]"
           },
           {
@@ -247,24 +261,28 @@
             "file_path": "/var/log/kern.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "kern",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/krb5kdc.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "krb5kdc",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/messages",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "messages",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/secure",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "secure",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
@@ -292,12 +310,14 @@
             "file_path": "/var/log/syslog",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "syslog",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
             "file_path": "/var/log/ufw.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ufw",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
@@ -311,6 +331,7 @@
             "file_path": "/var/log/user.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "user",
+            "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -7,6 +7,11 @@
       "files": {
         "collect_list": [
           {
+            "file_path": "/var/log/aide/aide.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "aide"
+          },
+          {
             "file_path": "/var/alternatives.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "alternatives",
@@ -27,9 +32,21 @@
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
-            "file_path": "/var/log/aide/aide.log",
+            "file_path": "/var/log/apache2/access_log",
             "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "aide"
+            "log_stream_name": "apache2/access"
+          },
+          {
+            "file_path": "/var/log/apache2/error_log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "apache2/error",
+            "timestamp_format": "[%a %b %d %H:%M:%S.%f %Y]"
+          },
+          {
+            "file_path": "/var/log/apache2/ssl_request_log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "apache2/ssl_request",
+            "timestamp_format": "[%d/%b/%Y:%H:%M:%S.%f %z]"
           },
           {
             "file_path": "/var/log/apt/history.log",

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -22,7 +22,9 @@
             "file_path": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "amazon-cloudwatch-agent",
-            "timestamp_format": "%Y/%m/%d %H:%M:%S"
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/amazon/ssm/*.log",

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -300,6 +300,13 @@
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "user",
             "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/home/vnc/.vnc/*.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "vnc",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%a %b %-d %H:%M:%S %Y"
           }
         ]
       }

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -137,58 +137,109 @@
     "metrics_collected": {
       "cpu": {
         "measurement": [
+          "cpu_usage_active",
+          "cpu_usage_guest",
+          "cpu_usage_guest_nice",
           "cpu_usage_idle",
           "cpu_usage_iowait",
-          "cpu_usage_user",
-          "cpu_usage_system"
+          "cpu_usage_irq",
+          "cpu_usage_nice",
+          "cpu_usage_softirq",
+          "cpu_usage_steal",
+          "cpu_usage_system",
+          "cpu_usage_user"
         ],
-        "metrics_collection_interval": 60,
         "resources": [
           "*"
-        ],
-        "totalcpu": false
+        ]
       },
       "disk": {
-        "measurement": [
-          "used_percent",
-          "inodes_free"
+        "ignore_file_system_types": [
+          "devtmpfs",
+          "sysfs",
+          "tmpfs"
         ],
-        "metrics_collection_interval": 60,
+        "measurement": [
+          "disk_total",
+          "disk_used",
+          "disk_used_percent"
+        ],
         "resources": [
           "*"
         ]
       },
       "diskio": {
         "measurement": [
-          "io_time",
-          "write_bytes",
-          "read_bytes",
-          "writes",
-          "reads"
+          "diskio_io_time",
+          "diskio_iops_in_progress",
+          "diskio_read_bytes",
+          "diskio_read_time",
+          "diskio_reads",
+          "diskio_write_bytes",
+          "diskio_write_time",
+          "diskio_writes"
         ],
-        "metrics_collection_interval": 60,
         "resources": [
           "*"
         ]
       },
+      "ethtool": {
+        "metrics_include": [
+          "ethtool_bw_in_allowance_exceeded",
+          "ethtool_bw_out_allowance_exceeded",
+          "ethtool_conntrack_allowance_exceeded",
+          "ethtool_linklocal_allowance_exceeded",
+          "ethtool_pps_allowance_exceeded"
+        ]
+      },
       "mem": {
         "measurement": [
+          "mem_active",
+          "mem_available",
+          "mem_available_percent",
+          "mem_buffered",
+          "mem_cached",
+          "mem_free",
+          "mem_inactive",
+          "mem_total",
+          "mem_used",
           "mem_used_percent"
-        ],
-        "metrics_collection_interval": 60
+        ]
+      },
+      "net": {
+        "measurement": [
+          "net_bytes_recv",
+          "net_bytes_sent",
+          "net_drop_in",
+          "net_drop_out",
+          "net_err_in",
+          "net_err_out",
+          "net_packets_sent",
+          "net_packets_recv"
+        ]
       },
       "netstat": {
         "measurement": [
-          "tcp_established",
-          "tcp_time_wait"
-        ],
-        "metrics_collection_interval": 60
+          "netstat_tcp_close",
+          "netstat_tcp_close_wait",
+          "netstat_tcp_closing",
+          "netstat_tcp_established",
+          "netstat_tcp_fin_wait1",
+          "netstat_tcp_fin_wait2",
+          "netstat_tcp_last_ack",
+          "netstat_tcp_listen",
+          "netstat_tcp_none",
+          "netstat_tcp_syn_recv",
+          "netstat_tcp_syn_sent",
+          "netstat_tcp_time_wait",
+          "udp_socket"
+        ]
       },
       "swap": {
         "measurement": [
+          "swap_used",
           "swap_used_percent"
-        ],
-        "metrics_collection_interval": 60
+        ]
       }
     }
   }

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -8,106 +8,106 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.logs",
-            "log_group_name": "/instance-logs/amazon-cloudwatch-agent",
-            "log_stream_name": "{instance_id}",
+            "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "amazon-cloudwatch-agent",
             "timestamp_format": "%Y/%m/%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/aide/aide.log",
-            "log_group_name": "/instance-logs/aide",
-            "log_stream_name": "{instance_id}"
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "aide"
           },
           {
             "file_path": "/var/log/apt/history.log",
-            "log_group_name": "/instance-logs/apt/history",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "apt/history",
             "multi_line_start_pattern": "Start-Date: {timestamp_format}",
             "timestamp_format": "%Y-%m-%d  %H:%M:%S"
           },
           {
             "file_path": "/var/log/dpkg.log",
-            "log_group_name": "/instance-logs/dpkg",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "dpkg",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/clamav/freshclam.log",
-            "log_group_name": "/instance-logs/clamav/freshclam",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "clamav/freshclam",
             "timestamp_format": "%a %b %d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/freshclam.log",
-            "log_group_name": "/instance-logs/clamav/freshclam",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "clamav/freshclam",
             "timestamp_format": "%a %b %d %H:%M:%S %Y"
           },
           {
             "file_path": "/var/log/clamav/lastscan.log",
-            "log_group_name": "/instance-logs/clamav/lastscan",
-            "log_stream_name": "{instance_id}"
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "clamav/lastscan"
           },
           {
             "file_path": "/var/log/cloud-init.log",
-            "log_group_name": "/instance-logs/cloud-init",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "cloud-init",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/cloud-init-output.log",
-            "log_group_name": "/instance-logs/cloud-init-output",
-            "log_stream_name": "{instance_id}"
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "cloud-init-output"
           },
           {
             "file_path": "/var/log/ipaclient-install.log",
-            "log_group_name": "/instance-logs/ipaclient-install",
-            "log_stream_name": "{instance_id}"
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "ipaclient-install"
           },
           {
             "file_path": "/var/log/ipaclient-uninstall.log",
-            "log_group_name": "/instance-logs/ipaclient-uninstall",
-            "log_stream_name": "{instance_id}"
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "ipaclient-uninstall"
           },
           {
             "file_path": "/var/log/ipaserver-install.log",
-            "log_group_name": "/instance-logs/ipaserver-install",
-            "log_stream_name": "{instance_id}"
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "ipaserver-install"
           },
           {
             "file_path": "/var/log/syslog",
-            "log_group_name": "/instance-logs/syslog",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "syslog",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/auth.log",
-            "log_group_name": "/instance-logs/auth",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "auth",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/daemon.log",
-            "log_group_name": "/instance-logs/daemon",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "daemon",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/debug",
-            "log_group_name": "/instance-logs/debug",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "debug",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/kern.log",
-            "log_group_name": "/instance-logs/kern",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance-id}",
+            "log_stream_name": "kern",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/messages",
-            "log_group_name": "/instance-logs/messages",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/instance-logs/{instance_id}",
+            "log_stream_name": "messages",
             "timestamp_format": "%b %d %H:%M:%S"
           }
         ]

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -304,7 +304,8 @@
             "file_path": "/var/log/unattended-upgrades/*.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "unattended-upgrades",
-            "timestamp_format": "%b %-d %H:%M:%S"
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
           },
           {
             "file_path": "/var/log/user.log",

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -7,7 +7,7 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+            "file_path": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "amazon-cloudwatch-agent",
             "timestamp_format": "%Y/%m/%d %H:%M:%S"

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -328,11 +328,11 @@
       },
       "ethtool": {
         "metrics_include": [
-          "ethtool_bw_in_allowance_exceeded",
-          "ethtool_bw_out_allowance_exceeded",
-          "ethtool_conntrack_allowance_exceeded",
-          "ethtool_linklocal_allowance_exceeded",
-          "ethtool_pps_allowance_exceeded"
+          "bw_in_allowance_exceeded",
+          "bw_out_allowance_exceeded",
+          "conntrack_allowance_exceeded",
+          "linklocal_allowance_exceeded",
+          "pps_allowance_exceeded"
         ]
       },
       "mem": {

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -84,7 +84,8 @@
             "file_path": "/var/log/cloud-init.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "cloud-init",
-            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
           },
           {
             "file_path": "/var/log/cloud-init-output.log",

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -177,56 +177,64 @@
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipa/cli",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipa/ipactl.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipa/ipactl",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipa-custodia.audit.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipa-custodia/audit",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipaclient-install.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipaclient-install",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipaclient-uninstall.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipaclient-uninstall",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipareplica-conncheck.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipareplica-conncheck",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipareplica-install.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipareplica-install",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/ipaserver-install.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "ipaserver-install",
             "multi_line_start_pattern": "{timestamp_format}",
-            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+            "timezone": "UTC"
           },
           {
             "file_path": "/var/log/kadmind.log",

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -1,7 +1,6 @@
 {
   "agent": {
-    "metrics_collection_interval": 60,
-    "run_as_user": "root"
+    "metrics_collection_interval": 60
   },
   "logs": {
     "logs_collected": {

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -359,6 +359,9 @@
         ]
       },
       "ethtool": {
+        "interface_exclude": [
+          "tun0"
+        ],
         "metrics_include": [
           "bw_in_allowance_exceeded",
           "bw_out_allowance_exceeded",

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -25,6 +25,12 @@
             "timestamp_format": "%Y-%m-%d  %H:%M:%S"
           },
           {
+            "file_path": "/var/log/auth.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "auth",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
             "file_path": "/var/log/dpkg.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "dpkg",
@@ -59,33 +65,6 @@
             "log_stream_name": "cloud-init-output"
           },
           {
-            "file_path": "/var/log/ipaclient-install.log",
-            "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "ipaclient-install"
-          },
-          {
-            "file_path": "/var/log/ipaclient-uninstall.log",
-            "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "ipaclient-uninstall"
-          },
-          {
-            "file_path": "/var/log/ipaserver-install.log",
-            "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "ipaserver-install"
-          },
-          {
-            "file_path": "/var/log/syslog",
-            "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "syslog",
-            "timestamp_format": "%b %d %H:%M:%S"
-          },
-          {
-            "file_path": "/var/log/auth.log",
-            "log_group_name": "/instance-logs/{local_hostname}",
-            "log_stream_name": "auth",
-            "timestamp_format": "%b %d %H:%M:%S"
-          },
-          {
             "file_path": "/var/log/daemon.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "daemon",
@@ -98,15 +77,179 @@
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
+            "file_path": "/var/log/dirsrv/slapd-*/access",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dirsrv/slapd/access",
+            "timestamp_format": "%d/%b/%Y:%H:%M:%S.%f %z"
+          },
+          {
+            "file_path": "/var/log/dirsrv/slapd-*/audit",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dirsrv/slapd/audit",
+            "timestamp_format": "%d/%b/%Y:%H:%M:%S.%f %z"
+          },
+          {
+            "file_path": "/var/log/dirsrv/slapd-*/errors",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dirsrv/slapd/errors",
+            "timestamp_format": "%d/%b/%Y:%H:%M:%S.%f %z"
+          },
+          {
+            "file_path": "/var/log/dnf.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dnf",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"
+          },
+          {
+            "file_path": "/var/log/dnf.librepo.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dnf/librepo",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"
+          },
+          {
+            "file_path": "/var/log/dnf.rpm.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "dnf/rpm",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"
+          },
+          {
+            "file_path": "/var/log/hawkey.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "hawkey",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"
+          },
+          {
+            "file_path": "/var/log/httpd/access_log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "httpd/access"
+          },
+          {
+            "file_path": "/var/log/httpd/error_log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "httpd/error",
+            "timestamp_format": "[%a %b %d %H:%M:%S.%f %Y]"
+          },
+          {
+            "file_path": "/var/log/httpd/ssl_request_log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "httpd/ssl_request",
+            "timestamp_format": "[%d/%b/%Y:%H:%M:%S.%f %z]"
+          },
+          {
+            "file_path": "/var/log/ipa/cli.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipa/cli",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipa/ipactl.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipa/ipactl",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipa-custodia.audit.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipa-custodia/audit",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipaclient-install.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipaclient-install",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipaclient-uninstall.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipaclient-uninstall",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipareplica-conncheck.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipareplica-conncheck",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipareplica-install.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipareplica-install",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/ipaserver-install.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "ipaserver-install",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+          },
+          {
+            "file_path": "/var/log/kadmind.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "kadmind",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
             "file_path": "/var/log/kern.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "kern",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
+            "file_path": "/var/log/krb5kdc.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "krb5kdc",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
             "file_path": "/var/log/messages",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "messages",
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/secure",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "secure",
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/sssd/ldap_child.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "sssd/ldap_child",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "(%Y-%m-%d %H:%M:%S):"
+          },
+          {
+            "file_path": "/var/log/sssd/sssd*.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "sssd",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "(%Y-%m-%d %H:%M:%S):"
+          },
+          {
+            "file_path": "/var/log/sudo.log",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "sudo",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%b %-d %H:%M:%S : "
+          },
+          {
+            "file_path": "/var/log/syslog",
+            "log_group_name": "/instance-logs/{local_hostname}",
+            "log_stream_name": "syslog",
             "timestamp_format": "%b %d %H:%M:%S"
           }
         ]

--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -114,6 +114,20 @@
     }
   },
   "metrics": {
+    "aggregation_dimensions": [
+      [
+        "AutoScalingGroupName"
+      ],
+      [
+        "ImageId"
+      ],
+      [
+        "InstanceId"
+      ],
+      [
+        "InstanceType"
+      ]
+    ],
     "append_dimensions": {
       "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
       "ImageId": "${aws:ImageId}",

--- a/tasks/install_Amazon.yml
+++ b/tasks/install_Amazon.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install AWS CloudWatch Agent RPM via yum
-  yum:
+  ansible.builtin.yum:
     name:
       - "{{ url }}"

--- a/tasks/install_Debian.yml
+++ b/tasks/install_Debian.yml
@@ -1,12 +1,12 @@
 ---
 - name: Install xz-utils (required when using deb parameter of apt module)
-  package:
+  ansible.builtin.package:
     name:
       - xz-utils
 - name: Download the AWS CloudWatch Agent Debian package
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ url }}"
     dest: /tmp/amazon-cloudwatch-agent.deb
 - name: Install AWS CloudWatch Agent Debian package
-  apt:
+  ansible.builtin.apt:
     deb: /tmp/amazon-cloudwatch-agent.deb

--- a/tasks/install_Debian.yml
+++ b/tasks/install_Debian.yml
@@ -5,8 +5,8 @@
       - xz-utils
 - name: Download the AWS CloudWatch Agent Debian package
   ansible.builtin.get_url:
-    url: "{{ url }}"
     dest: /tmp/amazon-cloudwatch-agent.deb
+    url: "{{ url }}"
 - name: Install AWS CloudWatch Agent Debian package
   ansible.builtin.apt:
     deb: /tmp/amazon-cloudwatch-agent.deb

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install AWS CloudWatch Agent RPM via dnf
-  dnf:
+  ansible.builtin.dnf:
     # The amazon-ssm-agent RPM is currently unsigned:
     # https://github.com/aws/amazon-ssm-agent/issues/235
     disable_gpg_check: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,13 @@
       paths:
         - "{{ role_path }}/tasks"
 
+# Install ethtool, since we want to allow this agent to use it to
+# collect information from the ENA if present.
+- name: Install ethtool
+  ansible.builtin.package:
+    name:
+      - ethtool
+
 # Note that we are using a single config file for all instances,
 # regardless of Linux distribution.  This means that the config file
 # may well (and most likely does) reference log files that do not

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Load var file with package URL based on the OS type
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -11,7 +11,7 @@
         - "{{ role_path }}/vars"
 
 - name: Load tasks file with install tasks based on the OS type
-  include: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -33,7 +33,7 @@
 # may well (and most likely does) reference log files that do not
 # exist on all instances.
 - name: Copy over CloudWatch Agent configuration
-  copy:
+  ansible.builtin.copy:
     src: amazon-cloudwatch-agent.json
     dest: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
     mode: 0600
@@ -43,16 +43,16 @@
 # it here because it will be started again during the idempotence test
 # and therefore will fail idempotence.
 - name: Enable AWS CloudWatch Agent
-  service:
+  ansible.builtin.service:
     name: amazon-cloudwatch-agent
     enabled: yes
 
 - name: Install rsyslog
-  package:
+  ansible.builtin.package:
     name:
       - rsyslog
 - name: Enable rsyslog
-  service:
+  ansible.builtin.service:
     name: rsyslog
     enabled: yes
 
@@ -60,7 +60,7 @@
 # so that the Amazon CloudWatch Agent can in turn forward them to
 # CloudWatch.
 - name: Forward journald log entries to rsyslog
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/systemd/journald.conf
     regexp: '{{ item.regex }}'
     line: '{{ item.line }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,9 +34,9 @@
 # exist on all instances.
 - name: Copy over CloudWatch Agent configuration
   ansible.builtin.copy:
-    src: amazon-cloudwatch-agent.json
     dest: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
     mode: 0600
+    src: amazon-cloudwatch-agent.json
 
 # The AWS CloudWatch Agent systemd unit kicks off a process that
 # starts the CloudWatch Agent and then dies.  Therefore we can't start
@@ -44,8 +44,8 @@
 # and therefore will fail idempotence.
 - name: Enable AWS CloudWatch Agent
   ansible.builtin.service:
-    name: amazon-cloudwatch-agent
     enabled: yes
+    name: amazon-cloudwatch-agent
 
 - name: Install rsyslog
   ansible.builtin.package:
@@ -53,20 +53,20 @@
       - rsyslog
 - name: Enable rsyslog
   ansible.builtin.service:
-    name: rsyslog
     enabled: yes
+    name: rsyslog
 
 # Configure systemd-journald to forward all journal logs to rsyslog,
 # so that the Amazon CloudWatch Agent can in turn forward them to
 # CloudWatch.
 - name: Forward journald log entries to rsyslog
   ansible.builtin.lineinfile:
-    path: /etc/systemd/journald.conf
-    regexp: '{{ item.regex }}'
-    line: '{{ item.line }}'
     # This forces lineinfile not to append the line if the regex fails
     # to match
     backrefs: yes
+    line: '{{ item.line }}'
+    path: /etc/systemd/journald.conf
+    regexp: '{{ item.regex }}'
   loop:
     - {regex: '^#?ForwardToSyslog', line: "ForwardToSyslog=yes"}
     - {regex: '^#?MaxLevelSyslog', line: "MaxLevelSyslog=debug"}


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes some improvements to the CloudWatch Agent configuration file.  It also modernizes the Ansible code by using FQCNs everywhere.

## 💭 Motivation and context ##

The CloudWatch Agent configuration file changes are the meat of this pull request, and these changes are being made for several reasons:
- To support cisagov/instance-cw-alarms-tf-module#5, which in turn supports cisagov/cool-sharedservices-freeipa#54
- To capture instance log files that were previously missing from the configuration file and hence not being forwarded to CloudWatch
- To make sure any CloudWatch Agent metrics that may be useful for debugging instance failures or improving instance performance are being sent to CloudWatch

The Ansible moderinization is just something I noticed while I was here.

This pull request also just happens to resolve cisagov/cool-system-internal#20.

## 🧪 Testing ##

I have deployed these configuration file changes to all of our staging COOL FreeIPA and OpenVPN instances and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.