### PR TITLE
Add duplicate log groups for CDM

### DIFF
--- a/files/amazon-cloudwatch-agent.json
+++ b/files/amazon-cloudwatch-agent.json
@@ -66,6 +66,12 @@
             "multi_line_start_pattern": "^type="
           },
           {
+            "file_path": "/var/log/audit/audit.log",
+            "log_group_name": "/instance-logs/audit",
+            "log_stream_name": "{local_hostname}",
+            "multi_line_start_pattern": "^type="
+          },
+          {
             "file_path": "/var/log/auth.log",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "auth",
@@ -285,9 +291,23 @@
             "timestamp_format": "%b %-d %H:%M:%S"
           },
           {
+            "file_path": "/var/log/messages",
+            "log_group_name": "/instance-logs/messages",
+            "log_stream_name": "{local_hostname}",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
             "file_path": "/var/log/secure",
             "log_group_name": "/instance-logs/{local_hostname}",
             "log_stream_name": "secure",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "timestamp_format": "%b %-d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/secure",
+            "log_group_name": "/instance-logs/secure",
+            "log_stream_name": "{local_hostname}",
             "multi_line_start_pattern": "{timestamp_format}",
             "timestamp_format": "%b %-d %H:%M:%S"
           },


### PR DESCRIPTION
## 🗣 Description ##

This pull request creates duplicate log groups for three log types in which CDM is interested.

See also cisagov/cool-sharedservices-cdm#39.

## 💭 Motivation and context ##

CDM desires access to our audit, secure, and messages logs, but they cannot cope with the logs when they are organized according to machine.  Therefore I am creating duplicate log groups for these three log types so that CDM can ingest them into Splunk.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.