### PR TITLE
Modify AWS CloudWatch agent to start after cloud-init

### DIFF
--- a/files/override.conf
+++ b/files/override.conf
@@ -1,0 +1,13 @@
+[Unit]
+# Having a service run after cloud-init.target is trickier than one
+# might expect because of a dependency cycle that is induced because
+# the default of DefaultDependencies=yes causes the default target
+# (usually multi-user.target) to depend on the service.  This is
+# described in great detail here:
+# https://serverfault.com/a/973985
+#
+# Note also that we are using a drop-in file so that we can leave the
+# real unit file untouched and need only specify the unit file
+# attributes that we want to change.
+After=cloud-init.target
+DefaultDependencies=no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: SystemD daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: "systemd daemon-reload"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,7 +19,11 @@ def test_packages(host, pkg):
 
 
 @pytest.mark.parametrize(
-    "f", ["/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"]
+    "f",
+    [
+        "/etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf",
+        "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json",
+    ],
 )
 def test_files(host, f):
     """Test that the expected files were installed."""
@@ -27,7 +31,6 @@ def test_files(host, f):
     assert host.file(f).is_file
     assert host.file(f).user == "root"
     assert host.file(f).group == "root"
-    assert host.file(f).mode == 0o600
 
 
 @pytest.mark.parametrize("service", ["amazon-cloudwatch-agent", "rsyslog"])

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,25 @@
     mode: 0600
     src: amazon-cloudwatch-agent.json
 
+# Modify AWS CloudWatch agent to start after cloud-init.  We sometimes
+# use cloud-init to set the hostname to the correct value, and
+# introducing this dependency ensures that this is allowed to happen
+# before the CloudWatch Agent starts up.
+#
+# See, for example, here:
+# https://github.com/cisagov/freeipa-server-tf-module/blob/a3b02be97d8f7c4cf44e80d3788d212344b320aa/cloud_init.tf#L23-L40
+- name: Ensure that CloudWatch Agent is started after cloud-init completes
+  block:
+    - name: Ensure that directory exists for CloudWatch Agent unit drop-in file
+      ansible.builtin.file:
+        path: /etc/systemd/system/amazon-cloudwatch-agent.service.d
+        recurse: true
+    - name: Copy drop-in file for CloudWatch Agent unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
+        src: override.conf
+      notify: "systemd daemon-reload"
+
 # The AWS CloudWatch Agent systemd unit kicks off a process that
 # starts the CloudWatch Agent and then dies.  Therefore we can't start
 # it here because it will be started again during the idempotence test


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the AWS CloudWatch agent to start after `cloud-init` is finished.

## 💭 Motivation and context ##

We sometimes use `cloud-init` to set the hostname to the correct value, and introducing this dependency ensures that this is allowed to happen before the CloudWatch agent starts up.  The CloudWatch agent uses the hostname to construct the log groups where the logs will appear, so the hostname needs to be correct when the agent starts up.

## 🧪 Testing ##

All automated tests pass.  I also built a new Kali AMI for our staging COOL as part of the testing for cisagov/kali-packer#149 and was able to verify that the AWS CloudWatch service indeed starts up only after `cloud-init.target` is reached:
```console
┌──(root@kali0)-[/usr/bin]
└─# systemd-analyze critical-chain amazon-cloudwatch-agent.service 
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

amazon-cloudwatch-agent.service @1min 48.876s
└─cloud-init.target @1min 48.823s
  └─cloud-final.service @1min 43.213s +5.608s
    └─multi-user.target @1min 43.194s
      └─docker.service @1min 23.372s +19.821s
        └─containerd.service @1min 22.489s +875ms
          └─network.target @1min 22.309s
            └─NetworkManager.service @1min 19.644s +2.664s
              └─dbus.service @1min 17.273s +2.323s
                └─basic.target @1min 17.158s
                  └─sockets.target @1min 17.157s
                    └─docker.socket @1min 17.028s +40ms
                      └─sysinit.target @1min 16.963s
                        └─cloud-init.service @1min 11.088s +5.871s
                          └─networking.service @1min 10.043s +1.041s
                            └─network-pre.target @1min 9.983s
                              └─cloud-init-local.service @8.347s +1min 1.633s
                                └─systemd-remount-fs.service @8.020s +243ms
                                  └─systemd-journald.socket @7.773s
                                    └─-.mount @7.446s
                                      └─-.slice @7.447s
```

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
