### PR TITLE
Use a drop-in config snippet instead of editing `/etc/systemd/journald.conf` directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,16 @@ jobs:
         architecture:
           - amd64
           - arm64
+        exclude:
+          # TODO: systemd-journald.socket fails to start under QEMU
+          # emulation starting with systemd version 256, so starting
+          # with that version the systemd-journald service cannot be
+          # restarted either.  Right now we support this case, but we
+          # can't test it until we have native ARM64 runners.
+          #
+          # See issue #61 for more details.
+          - architecture: arm64
+            platform: debian13-systemd
         platform:
           - amazonlinux2023-systemd
           - debian10-systemd

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
-- name: SystemD daemon-reload
+- name: Systemd daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true
-  listen: "systemd daemon-reload"
+
+- name: Restart systemd-journald
+  ansible.builtin.service:
+    name: systemd-journald.service
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Systemd daemon-reload
-  ansible.builtin.systemd:
-    daemon_reload: true
-
 - name: Restart systemd-journald
   ansible.builtin.service:
     name: systemd-journald.service

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -85,15 +85,22 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/cisagov/docker-debian13-ansible:latest
-    name: debian13-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # TODO: systemd-journald.socket fails to start under QEMU emulation
+  # starting with systemd version 256, so starting with that version
+  # the systemd-journald service cannot be restarted either.  Right
+  # now we support this case, but we can't test it until we have
+  # native ARM64 runners.
+  #
+  # See issue #61 for more details.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/cisagov/docker-debian13-ansible:latest
+  #   name: debian13-systemd-arm64
+  #   platform: arm64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,6 +1,7 @@
 """Module containing the tests for the default scenario."""
 
 # Standard Python Libraries
+import configparser
 import os
 
 # Third-Party Libraries
@@ -40,10 +41,10 @@ def test_services(host, service):
 
 
 def test_systemd_journald_config(host):
-    """Test that the journald config was altered as expected."""
-    f = host.file("/etc/systemd/journald.conf")
-    assert f.exists
-    assert f.is_file
-    assert f.contains(r"^ForwardToSyslog=yes")
-    assert not f.contains(r"^ForwardToSyslog=no")
-    assert f.contains(r"^MaxLevelSyslog=debug")
+    """Test that systemd-journald is configured as expected."""
+    cmd = host.run("systemd-analyze cat-config systemd/journald.conf")
+    assert cmd.rc == 0
+    config = configparser.ConfigParser(strict=False)
+    config.read_string(cmd.stdout)
+    assert config["Journal"]["ForwardToSyslog"]
+    assert config["Journal"]["MaxLevelSyslog"] == "debug"

--- a/tasks/install_Debian.yml
+++ b/tasks/install_Debian.yml
@@ -3,11 +3,13 @@
   ansible.builtin.package:
     name:
       - xz-utils
+
 - name: Download the AWS CloudWatch Agent Debian package
   ansible.builtin.get_url:
     dest: /tmp/amazon-cloudwatch-agent.deb
     mode: 0644
     url: "{{ url }}"
+
 - name: Install AWS CloudWatch Agent Debian package
   ansible.builtin.apt:
     deb: /tmp/amazon-cloudwatch-agent.deb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,7 +112,9 @@
         section: Journal
         value: "{{ item.value }}"
       loop:
-        - {option: ForwardToSyslog, value: true}
-        - {option: MaxLevelSyslog, value: debug}
+        - option: ForwardToSyslog
+          value: true
+        - option: MaxLevelSyslog
+          value: debug
       notify:
         - Restart systemd-journald

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,14 +68,17 @@
     enabled: true
     name: amazon-cloudwatch-agent
 
-- name: Install rsyslog
-  ansible.builtin.package:
-    name:
-      - rsyslog
-- name: Enable rsyslog
-  ansible.builtin.service:
-    enabled: true
-    name: rsyslog
+- name: Install and enable rsyslog
+  block:
+    - name: Install rsyslog
+      ansible.builtin.package:
+        name:
+          - rsyslog
+
+    - name: Enable rsyslog
+      ansible.builtin.service:
+        enabled: true
+        name: rsyslog
 
 # Configure systemd-journald to forward all journal logs to rsyslog,
 # so that the Amazon CloudWatch Agent can in turn forward them to

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
         dest: /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
         mode: 0644
         src: override.conf
-      notify: "systemd daemon-reload"
+      notify: "Systemd daemon-reload"
 
 # The AWS CloudWatch Agent systemd unit kicks off a process that
 # starts the CloudWatch Agent and then dies.  Therefore we can't start
@@ -80,14 +80,35 @@
 # Configure systemd-journald to forward all journal logs to rsyslog,
 # so that the Amazon CloudWatch Agent can in turn forward them to
 # CloudWatch.
-- name: Forward journald log entries to rsyslog
-  ansible.builtin.lineinfile:
-    # This forces lineinfile not to append the line if the regex fails
-    # to match
-    backrefs: true
-    line: "{{ item.line }}"
-    path: /etc/systemd/journald.conf
-    regexp: "{{ item.regex }}"
-  loop:
-    - {regex: "^#?ForwardToSyslog", line: "ForwardToSyslog=yes"}
-    - {regex: "^#?MaxLevelSyslog", line: "MaxLevelSyslog=debug"}
+- name: Configure systemd-journald to forward log entries to rsyslog
+  block:
+    - name: >-
+        Ensure that the directory where the systemd-journald drop-in
+        will live actually exists
+      ansible.builtin.file:
+        group: root
+        mode: 0755
+        owner: root
+        path: /etc/systemd/journald.conf.d
+        state: directory
+
+    - name: >-
+        Configure systemd-journald to forward log entries to rsyslog
+      community.general.ini_file:
+        group: root
+        mode: 0644
+        # This is just to maintain the look and feel of the
+        # /etc/systemd/journald.conf file as provided by
+        # systemd-journald.
+        no_extra_spaces: true
+        option: "{{ item.option }}"
+        owner: root
+        path: >-
+          /etc/systemd/journald.conf.d/99-ansible-role-cloudwatch-agent.conf
+        section: Journal
+        value: "{{ item.value }}"
+      loop:
+        - {option: ForwardToSyslog, value: true}
+        - {option: MaxLevelSyslog, value: debug}
+      notify:
+        - Restart systemd-journald

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,7 @@
         mode: 0755
         path: /etc/systemd/system/amazon-cloudwatch-agent.service.d
         state: directory
+
     - name: Copy drop-in file for CloudWatch Agent unit
       ansible.builtin.copy:
         dest: /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,7 @@
         dest: /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
         mode: 0644
         src: override.conf
+      register: copy_dropin_file
 
 # The AWS CloudWatch Agent systemd unit kicks off a process that
 # starts the CloudWatch Agent and then dies.  Therefore we can't start
@@ -65,7 +66,9 @@
 # and therefore will fail idempotence.
 - name: Enable AWS CloudWatch Agent
   ansible.builtin.systemd_service:
-    daemon_reload: true
+    # There is no need to perform a daemon-reload unless the config
+    # has changed.
+    daemon_reload: "{{ copy_dropin_file.changed }}"
     enabled: true
     name: amazon-cloudwatch-agent
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,14 +57,14 @@
         dest: /etc/systemd/system/amazon-cloudwatch-agent.service.d/override.conf
         mode: 0644
         src: override.conf
-      notify: "Systemd daemon-reload"
 
 # The AWS CloudWatch Agent systemd unit kicks off a process that
 # starts the CloudWatch Agent and then dies.  Therefore we can't start
 # it here because it will be started again during the idempotence test
 # and therefore will fail idempotence.
 - name: Enable AWS CloudWatch Agent
-  ansible.builtin.service:
+  ansible.builtin.systemd_service:
+    daemon_reload: true
     enabled: true
     name: amazon-cloudwatch-agent
 
@@ -76,7 +76,8 @@
           - rsyslog
 
     - name: Enable rsyslog
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
+        daemon_reload: true
         enabled: true
         name: rsyslog
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to use a drop-in config snippet instead of editing `/etc/systemd/journald.conf` directly.  It also reworks the `molecule` test code.

## 💭 Motivation and context ##

- Using a drop-in config snippet is the preferred method [according to the documentation](https://man7.org/linux/man-pages/man5/journald.conf.5.html#CONFIGURATION_DIRECTORIES_AND_PRECEDENCE).
- This change also [partially fixes](https://github.com/cisagov/freeipa-server-packer/actions/runs/9192084057/job/25280049581?pr=129) a [broken build](https://github.com/cisagov/freeipa-server-packer/actions/runs/9185851377/job/25260568631?pr=129) in cisagov/freeipa-server-packer#129 where `/etc/systemd/journald.conf` does not exist on Fedora 40.
- Using `systemd-analyze cat-config` is a better way (than checking config files directly) to verify that the configuration changes are actually being utilized by `systemd-journald`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.